### PR TITLE
build: create workflow to enable true `fast-forward` merge

### DIFF
--- a/.github/workflows/fast-forward-pr-merge-init.md
+++ b/.github/workflows/fast-forward-pr-merge-init.md
@@ -1,0 +1,67 @@
+# GitHub Actions Workflow: `fast-forward-pr-merge-init.yml`
+
+This document explains the purpose, logic, and security rationale behind the [`.github/workflows/fast-forward-pr-merge-init.yml`](./.github/workflows/fast-forward-pr-merge-init.yml) workflow in this repository.
+
+## Overview
+
+This workflow is the **first phase** of a two-phase secure PR merge process designed to control and secure the merging of pull requests (PRs) via the addition of a special `fast-forward` label to a pull request. It ensures that only users with sufficient repository permissions (`write` or `admin`) can trigger a merge, and provides clear feedback to users who lack the required permissions.
+
+If the user passes these checks, a second workflow, [`fast-forward-pr-merge-privileged.yml`](./fast-forward-pr-merge-privileged.md), is triggered to perform the actual fast-forward merge and post the final result.
+
+It is especially important when accepting contributions from external users via a forked repository, which is how most open source contributions are made.
+
+## When Does This Workflow Run?
+
+The workflow is triggered when a pull request receives the `fast-forward` label (`pull_request` event, type `labeled`).
+
+## What Does the Workflow Do?
+
+### 1. Checks User Permissions
+
+- The workflow determines the GitHub username of the user who added the label.
+- It uses the GitHub CLI (`gh api`) to fetch the user's permission level on the repository (e.g., `read`, `triage`, `write`, `maintain`, `admin`).
+- The permission is stored for use in later steps.
+
+### 2. Handles Insufficient Permissions
+
+- If the user **DOES NOT** have `write` or `admin` permissions:
+  - The workflow fails with a clear error message, preventing any further merge automation.
+  - The privileged workflow (second phase) will post a comment on the PR stating that the user does not have permission to merge the PR and should contact a member of the [API Standards Team](https://github.com/orgs/ukhsa-collaboration/teams/api-standards-team) for assistance.
+
+### 3. Event Payload Publishing
+
+- If the user **DOES** have `write` or `admin` permissions:
+  - The workflow saves the full event payload (the GitHub event data) as an artifact for use with the second phase of the workflow, but it's also useful for auditing or debugging purposes.
+
+## Why Is This Workflow Needed?
+
+- **True Fast-Forward Merges:** GitHub's "Rebase and merge" option is not a true fast-forward merge. Instead, it rewrites commit SHAs and the process strips any commit signatures, which can break commit verification and audit trails. This workflow enables a genuine fast-forward merge, preserving original commit SHAs and signatures (at least until GitHub support a true fast-forward merge).
+  - See: [GitHub Docs – About merge methods on GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github#rebasing-and-merging-your-commits)
+  - See: [GitHub Community - Feature Request: Only allow for --ff merges for PRs](https://github.com/orgs/community/discussions/4618)
+  - See: [GitHub Community – GPG signature lost when merging a PR](https://github.com/orgs/community/discussions/10410)
+
+- **Preserves Conventional Commit History:** True fast-forward merges retain the original commits and their message structure intact, which is especially valuable for our adoption of [Conventional Commits](https://www.conventionalcommits.org/). Unlike GitHub's `squash-merges` which combine all changes into a single commit with limited control over the structure of the final commit message (making it difficult to ensure it adheres to the conventional commit standard). This enables automated changelog generation, better traceability of features and fixes, and more meaningful project history.
+
+## Why is the Workflow Split into Two Phases?
+
+Splitting the merge process into two distinct workflows is a best practice for securing GitHub Actions, especially when privileged operations (like merging to a protected branch) are involved. This approach is recommended by GitHub Security Lab and is designed to mitigate several classes of vulnerabilities:
+
+### Security Boundaries
+
+By separating the unprivileged (label-triggered) phase from the privileged (merge-executing) phase, you create a strong security boundary. The first workflow runs with minimal permissions and only performs checks and artifact publishing. The second, privileged workflow (triggered by `workflow_run`) runs with elevated permissions and only after all checks have passed.
+
+### Prevents Privilege Escalation
+
+If a single workflow both checked permissions and performed the merge, an attacker could potentially exploit timing or event confusion such as **Time Of Check to Time Of Use** ([TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use)) attacks to escalate privileges or inject malicious code between steps. By splitting the workflows, the privileged phase only runs after the unprivileged phase has completed and its outputs (artifacts) are validated.
+
+### Mitigates Artifact Poisoning
+
+Artifacts passed from the unprivileged to the privileged workflow are treated as untrusted. This separation allows you to validate and sanitise any data before it is used in a privileged context, reducing the risk of artifact poisoning attacks.
+
+### Reduces Risk from Untrusted Triggers
+
+Triggers like `issue_comment` or `pull_request_target` can be abused by attackers to execute workflows with elevated permissions. By using a label gate and a two-phase approach, you ensure that only trusted actors (with `write` or `admin` permissions) can initiate the privileged merge, and that the code being merged is exactly what was reviewed and approved.
+
+### Aligns with GitHub Security Guidance
+
+GitHub’s own security research recommends splitting workflows into unprivileged and privileged components, using `workflow_run` as a secure handoff point. This pattern is now widely adopted in the open source community to prevent supply chain attacks and workflow abuse.

--- a/.github/workflows/fast-forward-pr-merge-init.yml
+++ b/.github/workflows/fast-forward-pr-merge-init.yml
@@ -1,0 +1,52 @@
+name: Fast Forward PR Merge Initialise
+
+on:
+  pull_request:
+    types: [labeled]
+
+    branches:
+      - main
+
+jobs:
+  initialise-workflow:
+    if: |
+      github.event.label.name == 'fast-forward' &&
+      !github.event.pull_request.closed_at &&
+      github.event.pull_request.state == 'open'
+
+    name: Initialise Workflow
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+
+    env:
+      USERNAME: ${{ github.actor }}
+
+    steps:
+
+      - name: Get permissions
+        id: permission
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_API_VERSION: '2022-11-28'
+        run: |
+          echo "Fetching permissions for user: $USERNAME"
+          RESPONSE=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: $GH_API_VERSION" \
+            repos/$GITHUB_REPOSITORY/collaborators/$USERNAME/permission | jq -r .permission)
+          echo "Permission: $RESPONSE"
+          echo "permission=$RESPONSE" >> $GITHUB_OUTPUT
+
+      - name: Set failure message
+        uses: actions/github-script@v7
+        if: ${{ steps.permission.outputs.permission != 'write' && steps.permission.outputs.permission != 'admin' }}
+        with:
+          script: core.setFailed("You do not have permission to merge this PR. Please contact a member of ${{ github.server_url }}/orgs/${{ github.repository_owner }}/teams/api-standards-team for assistance.");
+
+      - name: Upload Event Artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: event-artifact
+          path: ${{ github.event_path }}

--- a/.github/workflows/fast-forward-pr-merge-privileged.md
+++ b/.github/workflows/fast-forward-pr-merge-privileged.md
@@ -1,0 +1,53 @@
+# GitHub Actions Workflow: `fast-forward-pr-merge-privileged.yml`
+
+This document explains the purpose, logic, and security rationale behind the [`.github/workflows/fast-forward-pr-merge-privileged.yml`](./fast-forward-pr-merge-privileged.yml) workflow in this repository.
+
+## Purpose and Overview
+
+This workflow is the **second phase** of a two-phase pull request (PR) merge process. It works in tandem with the [`fast-forward-pr-merge-init.yml`](./fast-forward-pr-merge-init.md) workflow to allow privileged users to trigger a fast-forward merge of a PR by adding the `fast-forward` label to an open pull request.
+
+The workflow ensures that only users with `write` or `admin` permissions can perform this action, and that the PR is in a clean, mergeable state. It provides clear feedback to users and maintains a full audit trail of the event and actions taken.
+
+## How Does It Work?
+
+### 1. Triggering
+
+- The workflow is triggered by a `workflow_run` event, specifically when the `Fast Forward PR Merge Initialise` workflow completes.
+- It only proceeds if the initial workflow succeeded and the event was an `pull_request` being labelled with `fast-forward` and is still open.
+
+### 2. Importing and Validating Event Data
+
+- Downloads the event artifact created by the initial workflow, which contains the full GitHub event payload (including the PR and label details).
+
+### 3. On Failure
+
+- If the initial workflow failed, this job posts a failure comment to the PR, sets a failure status, and removes the `fast-forward` label.
+
+### 4. On Success and Permission Check
+
+- If the initial workflow succeeded and the PR is still open and labelled correctly:
+  - Checks the permissions of the user who triggered the label.
+  - If the user does **not** have `write` or `admin` permissions at the time of merge, posts a failure comment and removes the label.
+
+### 5. Fast-Forward Merging
+
+- If all checks pass and the PR is in a `clean` (mergeable) state:
+  - Checks out the incoming PR branch and the base branch.
+  - Rebases the base branch onto the PR branch (fast-forward merge).
+  - Pushes the updated base branch to GitHub.
+- If the PR is not mergeable (e.g., conflicts), it does not attempt the merge and posts a failure comment.
+- After any attempt, the `fast-forward` label is removed from the PR.
+
+### 6. Feedback and Audit Trail
+
+- Posts a comment on the PR indicating success or failure, with a link to the workflow run for details.
+- Maintains a full audit trail by saving event data and merge results.
+
+## Why Is This Workflow Needed?
+
+- **True Fast-Forward Merges:** GitHub's "Rebase and merge" option is not a true fast-forward merge. Instead, it rewrites commit SHAs and the process strips any commit signatures, which can break commit verification and audit trails. This workflow enables a genuine fast-forward merge, preserving original commit SHAs and signatures (at least until GitHub supports a true fast-forward merge).
+  - See: [GitHub Docs – About merge methods on GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github#rebasing-and-merging-your-commits)
+  - See: [GitHub Community - Feature Request: Only allow for --ff merges for PRs](https://github.com/orgs/community/discussions/4618)
+  - See: [GitHub Community – GPG signature lost when merging a PR](https://github.com/orgs/community/discussions/10410)
+
+- **Preserves Conventional Commit History:** True fast-forward merges retain the original commits and their message structure intact, which is especially valuable for our adoption of [Conventional Commits](https://www.conventionalcommits.org/). Unlike GitHub's `squash-merges` which combine all changes into a single commit with limited control over the structure of the final commit message (making it difficult to ensure it adheres to the conventional commit standard). This enables automated changelog generation, better traceability of features and fixes, and more meaningful project history.

--- a/.github/workflows/fast-forward-pr-merge-privileged.yml
+++ b/.github/workflows/fast-forward-pr-merge-privileged.yml
@@ -1,0 +1,269 @@
+name: Fast Forward PR Merge Complete
+on:
+  workflow_run:
+    workflows: ["Fast Forward PR Merge Initialise"]
+    types:
+      - completed
+
+jobs:
+
+  import-event:
+    name: Import Event Details
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+
+    outputs:
+      trigger_event: ${{ steps.read-artifact.outputs.event_json }}
+
+    steps:
+      - name: 'Download artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: event-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: 'Read artifact'
+        id: read-artifact
+        run: |
+          echo "Reading artifact"
+          echo "event_json=$(cat event.json | jq -c)" >> $GITHUB_OUTPUT
+
+  on-failure:
+    name: On Failure
+    needs: import-event
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    env:
+      PULL_NUMBER: ${{ fromJson(needs.import-event.outputs.trigger_event).pull_request.number}}
+
+    steps:
+      # Post a failure message when the triggering workflow run fails.
+      - name: Add failure comment to PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_NUMBER: ${{ env.PULL_NUMBER }}
+          body: |
+            ### ⚠️ PR cannot be merged in! ⚠️
+
+            Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}) for details.
+        run: |
+          echo "Adding failure comment to PR"
+          RESPONSE=$(gh pr comment $PULL_NUMBER --repo "$GITHUB_REPOSITORY" -b "$body")
+          echo "response: $RESPONSE"
+
+      - name: Set failure message
+        uses: actions/github-script@v7
+        if: ${{ always() }}
+        with:
+          script: core.setFailed("Please check the workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }} for details.");
+
+      - name: Remove label
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_NUMBER: ${{ env.PULL_NUMBER}}
+        run: |
+          echo "Removing 'fast-forward' label from PR"
+          RESPONSE=$(gh pr edit $PULL_NUMBER --repo "$GITHUB_REPOSITORY" --remove-label "fast-forward")
+          echo "response: $RESPONSE"
+
+  on-success:
+    name: On Success
+    needs: import-event
+    # Run only if
+    # 1. The workflow run was triggered by a pull request.
+    # 2. The workflow run was successful.
+    # 3. The pull request was labeled with 'fast-forward'.
+    # 4. The pull request is still open and not closed.
+    if: |
+      ${{ github.event.workflow_run.event == 'pull_request' }} &&
+      ${{ github.event.workflow_run.conclusion == 'success' }} &&
+      ${{ fromJson(needs.import-event.outputs.trigger_event).pull_request }} &&
+      ${{ fromJson(needs.import-event.outputs.trigger_event).action == 'labeled' }} &&
+      ${{ fromJson(needs.import-event.outputs.trigger_event).label.name == 'fast-forward' }} &&
+      ${{ !fromJson(needs.import-event.outputs.trigger_event).pull_request.closed_at }} &&
+      ${{ fromJson(needs.import-event.outputs.trigger_event).pull_request.state == 'open' }}
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    outputs:
+      user_permission: ${{ steps.permission.outputs.permission }}
+
+    env:
+      PULL_NUMBER: ${{ fromJson(needs.import-event.outputs.trigger_event).pull_request.number}}
+
+    steps:
+
+      - name: Get user permissions
+        id: permission
+        env:
+          USERNAME: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_API_VERSION: '2022-11-28'
+        run: |
+          echo "Fetching permissions for user: $USERNAME"
+          RESPONSE=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: $GH_API_VERSION" \
+            repos/$GITHUB_REPOSITORY/collaborators/$USERNAME/permission | jq -r .permission)
+          echo "Permission: $RESPONSE"
+          echo "permission=$RESPONSE" >> $GITHUB_OUTPUT
+
+      # Post a failure message when user doesn't have the required permissions to merge the PR.
+      - name: Add failure comment to PR
+        if: ${{ steps.permission.outputs.permission != 'write' && steps.permission.outputs.permission != 'admin' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_NUMBER: ${{ env.PULL_NUMBER }}
+          body: |
+            ### ⚠️ You do not have permission to merge this PR! ⚠️
+
+            Please contact a member of the [API Standards Team](${{ github.server_url }}/orgs/${{ github.repository_owner }}/teams/api-standards-team) for assistance.
+        run: |
+          echo "Adding failure comment to PR"
+          RESPONSE=$(gh pr comment $PULL_NUMBER --repo "$GITHUB_REPOSITORY" -b "$body")
+          echo "response: $RESPONSE"
+
+      - name: Set failure message
+        uses: actions/github-script@v7
+        if: ${{ steps.permission.outputs.permission != 'write' && steps.permission.outputs.permission != 'admin' }}
+        with:
+          script: core.setFailed("You do not have permission to merge this PR. Please contact a member of ${{ github.server_url }}/orgs/${{ github.repository_owner }}/teams/api-standards-team for assistance.");
+
+      - name: Remove label
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_NUMBER: ${{ env.PULL_NUMBER }}
+        run: |
+          echo "Removing 'fast-forward' label from PR"
+          RESPONSE=$(gh pr edit $PULL_NUMBER --repo "$GITHUB_REPOSITORY" --remove-label "fast-forward")
+          echo "response: $RESPONSE"
+
+  merge_comment:
+    name: FF Merge PR
+    needs:
+      - import-event
+      - on-success
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      contents: write
+
+    # Run only if
+    # 1. The user has write or admin permissions on the repository.
+    if: ${{ needs.on-success.outputs.user_permission == 'write' || needs.on-success.outputs.user_permission == 'admin' }}
+
+    env:
+      PULL_NUMBER: ${{ fromJson(needs.import-event.outputs.trigger_event).pull_request.number }}
+      ERROR_MESSAGE: |
+        ### ⚠️ PR cannot be merged in! ⚠️
+
+        Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Get details of the PR. The target and base branch. And also whether the PR can be merged in or not.
+      - name: Get PR details
+        id: get-pr-details
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_NUMBER: ${{ env.PULL_NUMBER }}
+          GH_API_VERSION: '2022-11-28'
+        run: |
+          echo "Fetching pull request details"
+          RESPONSE=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: $GH_API_VERSION" \
+            repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER)
+          echo "response: $RESPONSE"
+          echo "data=$RESPONSE" >> $GITHUB_OUTPUT
+
+      # Merge (rebase) the PR if it is allowed.
+      - name: Merge the PR
+        id: merge-status
+        shell: bash
+        env:
+          MERGEABLE_STATUS: ${{ fromJson(steps.get-pr-details.outputs.data).mergeable_state }}
+          BASE_BRANCH: ${{ fromJson(steps.get-pr-details.outputs.data).base.ref }}
+          HEAD_BRANCH: pull/${{ env.PULL_NUMBER }}/head
+          # this is used to perform the final push to the base branch to allow the standard push triggers to run.
+          REMOTE_URL: https://${{ secrets.FAST_FORWARD_MERGE_TOKEN }}@github.com/${{ github.repository }}.git
+          SUCCESS_MESSAGE: |
+            ### 🎉 Success! 🎉
+
+            PR successfully Fast Forward merged in ✅.
+        run: |
+          if [ "$MERGEABLE_STATUS" = "clean" ]; then
+            git config --global user.email "<>"
+            git config --global user.name "GitHub Actions"
+            git fetch origin +refs/$HEAD_BRANCH:refs/heads/$HEAD_BRANCH
+            git checkout $HEAD_BRANCH
+            git pull origin $HEAD_BRANCH
+            git checkout $BASE_BRANCH
+            git pull origin $BASE_BRANCH
+            git rebase $HEAD_BRANCH
+            git remote set-url origin $REMOTE_URL
+            git push origin $BASE_BRANCH
+            {
+              echo 'message<<EOF'
+              echo "${{ env.SUCCESS_MESSAGE }}"
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo 'message<<EOF'
+              echo "${{ env.ERROR_MESSAGE }}"
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      # Post a success/failure comment to the PR.
+      - name: Add comment to PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_NUMBER: ${{ env.PULL_NUMBER }}
+          body: ${{ steps.merge-status.outputs.message }}
+        run: |
+          echo "Adding success/failure comment to PR"
+          RESPONSE=$(gh pr comment $PULL_NUMBER --repo "$GITHUB_REPOSITORY" -b "$body")
+          echo "response: $RESPONSE"
+
+      # Post a failure message when any of the previous steps fail.
+      - name: Add failure comment to PR
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_NUMBER: ${{ env.PULL_NUMBER }}
+          body: ${{ env.ERROR_MESSAGE }}
+        run: |
+          echo "Adding failure comment to PR"
+          RESPONSE=$(gh pr comment $PULL_NUMBER --repo "$GITHUB_REPOSITORY" -b "$body")
+          echo "response: $RESPONSE"
+
+      - name: Remove label
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_NUMBER: ${{ env.PULL_NUMBER }}
+        run: |
+          echo "Removing 'fast-forward' label from PR"
+          RESPONSE=$(gh pr edit $PULL_NUMBER --repo "$GITHUB_REPOSITORY" --remove-label "fast-forward")
+          echo "response: $RESPONSE"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,5 +8,8 @@
   "MD013": false,
   "MD024": {
     "siblings_only": true
+  },
+  "MD029": {
+    "style": "one"
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,8 +180,8 @@ For more information, see GitHub's documentation on [signing commits](https://do
 Before opening a new issue:
 
 1. **[Search existing issues](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments)** to avoid duplicates
-2. **Use issue templates** if available
-3. **Be clear and specific** about:
+1. **Use issue templates** if available
+1. **Be clear and specific** about:
    - What needs to be changed/added
    - Why it's important
    - Any relevant context
@@ -200,9 +200,9 @@ Before opening a new issue:
    git checkout -b fix/issue-you-are-fixing
    ```
 
-2. **Make your changes** following the [development guidelines](#development-guidelines) below.
-3. **Test your changes** (see [Testing Guidelines](#testing-guidelines))
-4. **Commit your changes** with clear commit messages and sign them (see [Signed Commits](#signed-commits)):
+1. **Make your changes** following the [development guidelines](#development-guidelines) below.
+1. **Test your changes** (see [Testing Guidelines](#testing-guidelines))
+1. **Commit your changes** with clear commit messages and sign them (see [Signed Commits](#signed-commits)):
 
 We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for commit messages. This provides a standardised format that makes the commit history more readable and enables automated tools for versioning and changelog generation.
 
@@ -273,9 +273,9 @@ Resolves issue #123"
     >
     > Always use [`rebase`](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase) instead of `merge` when keeping your branch up to date with the `main` branch.
 
-2. **[link PR to issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)** if you are solving one.
+1. **[link PR to issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)** if you are solving one.
 
-3. **Push your changes** to your branch/fork:
+1. **Push your changes** to your branch/fork:
 
     If its your fist push to the branch you can use:
 
@@ -295,30 +295,47 @@ Resolves issue #123"
     git push --force-with-lease origin your-branch-name
     ```
 
-4. **Create a Pull Request** from your branch/fork to the main repository
+1. **Create a Pull Request** from your branch/fork to the main repository
 
     if you are a member of the `ukhsa-collaboration` GitHub organisation, you can create a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) directly from your branch.
 
     If you are an external contributor, you can create a [pull request from your fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork) to the main repository.
 
-5. **Fill in the PR template** with all relevant information
+1. **Fill in the PR template** with all relevant information
 
-6. **Request a review** from maintainers
+1. **Request a review** from maintainers
 
-7. **Address any feedback** provided during the review process. When making changes to address feedback:
+1. **Address any feedback** provided during the review process. When making changes to address feedback:
    - Make additional commits while the PR is under review
    - Once approved, consider squashing related commits for a cleaner history
    - Use descriptive commit messages that explain the changes
 
-8. **Prepare for merge**: Before your PR is merged, you may be asked to squash your commits to maintain a clean project history.
+1. **Prepare for merge**: Before your PR is merged, make sure your branch is up to date with the latest changes from the `main` branch.
 
     You should be able to do this from the [GitHub UI](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/keeping-your-pull-request-in-sync-with-the-base-branch) or from the command line.
 
-    If you are an external contributor, you can use the following commands to squash your commits:
+    If you are an external contributor, you can use the following commands to keep your branch up to date with the `main` branch:
+
+    ```bash
+    # from your feature branch
+    git fetch upstream
+    git rebase upstream/main
+    ```
+
+    If you are a member of the `ukhsa-collaboration` GitHub organisation, you can use the following commands to keep your branch up to date with the `main` branch:
+
+    ```bash
+    # from your feature branch
+    git fetch
+    git rebase origin/main
+    ```
+
+    Occasionally you may also be asked to squash your commits to maintain a clean project history. If you are an external contributor, you can use the following commands to squash your commits:
 
     ```bash
     # Squash multiple commits into one
-    git rebase -i HEAD~[number of commits to squash]
+    git rebase -i HEAD~{number of commits to squash}
+    # and follow the instructions in the editor to squash your commits
     # or squash all commits since branching from main
     git fetch upstream
     git rebase -i upstream/main
@@ -328,20 +345,29 @@ Resolves issue #123"
 
     ```bash
     # Squash multiple commits into one
-    git rebase -i HEAD~[number of commits to squash]
+    git rebase -i HEAD~{number of commits to squash}
+    # and follow the instructions in the editor to squash your commits
     # or squash all commits since branching from main
     git fetch
-    git rebase -i main
+    git rebase -i origin/main
     ```
 
     > [!NOTE]
     > This repository maintains a [linear commit history](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-linear-history).
     >
-    > Always use [`rebase`](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase) instead of `merge` when keeping your branch up to date with the `main` branch.
+    > Always use [`rebase`](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase) instead of `merge` when keeping your branch up to date with the `main` branch (see previous step).
 
-9. **Merge the PR**: Once approved and all status checks have passed, you can merge the PR into the main branch. If you're an external contributor, this may be done by a maintainer.
+1. **Merge the PR**: Once approved and all status checks have passed, including the branch being up to date with main, you can trigger a `fast-forward` merge by adding the `fast-forward` label to the pull request. This will initiate an automated, permission-checked `fast-forward` merge process. Only users with `write` or `admin` permissions on the repository can trigger this action. If you're an external contributor, a maintainer may need to do this for you, as the automated process only responds to this tag when it has been added by an authorised user.
 
-10. Congratulations! 🎉🎉 You've successfully contributed to the UKHSA API Guidelines, any documentation changes will be automatically deployed to the [UKHSA API Guidelines](https://ukhsa-collaboration.github.io/api-guidelines/) site.
+    The merge process is handled by our two-phase GitHub Actions workflow:
+    - **[Phase 1](./.github/workflows/fast-forward-pr-merge-init.md):** Checks your permissions and PR status when you add the `fast-forward` label.
+    - **[Phase 2](./.github/workflows/fast-forward-pr-merge-privileged.md):** If you have sufficient permissions and the PR is mergeable, the workflow will perform a true `fast-forward` merge and post the result as a comment on the PR.
+
+    If you do not have permission, the workflow will notify you and request you contact a member of the [API Standards Team](https://github.com/orgs/ukhsa-collaboration/teams/api-standards-team).
+
+    Information on why we use a non-standard GitHub merge process can be found in the [`fast-forward-pr-merge-init.md`](./.github/workflows/fast-forward-pr-merge-init.md#why-is-this-workflow-needed) documentation.
+
+1. Congratulations! 🎉🎉 You've successfully contributed to the UKHSA API Guidelines, any documentation changes will be automatically deployed to the [UKHSA API Guidelines](https://ukhsa-collaboration.github.io/api-guidelines/) site.
 
 ## Development Guidelines
 


### PR DESCRIPTION
to overcome the shortcomings of GitHubs merge strategies this workflow seeks to enable true `fast-forward` merge of a PR through the use of a special `fast-forward` label to a pull request.

also includes documentation for the new workflow and updates to the `CONTRIBUTING.md` to explain how to merge pull requests.